### PR TITLE
Make sources buildable on VS 2013

### DIFF
--- a/WebSharper.Charting/WebSharper.Charting.fsproj
+++ b/WebSharper.Charting/WebSharper.Charting.fsproj
@@ -30,7 +30,7 @@
     <Name>WebSharper.Charting</Name>
     <RootNamespace>WebSharper.Charting</RootNamespace>
     <AssemblyName>WebSharper.Charting</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <WarningLevel>3</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/WebSharper.Charting/app.config
+++ b/WebSharper.Charting/app.config
@@ -23,6 +23,6 @@
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
   </startup>
 </configuration>


### PR DESCRIPTION
When testing the previous PR on VS 2013 I found out I need to change 4.5 -> 4.0
On VS 2013 the `WebSharper.Charting.Test` is not runnable now because of the binding redirect as mentioned in https://github.com/intellifactory/websharper.charting/pull/3. I will prepare something similar to [Assembly redirect in PowerShell](http://stackoverflow.com/questions/24181557/powershell-config-assembly-redirect/33302645#33302645).
